### PR TITLE
Reformat responses + check if user has support role

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -8,71 +8,31 @@ const ddog= new StatsD();
 const options = {
     '1': {
       description: 'Patreon/Lootbox issues or questions',
-      message: () => `**__Patreon Perks__**
-      Make sure you have your Discord linked with your Patreon.
-      If you haven't, You can do that by going to the Apps section from your user settings.
-      <https://www.patreon.com/settings/apps>
-      After successfully doing so, you will have the donor roles.
-      
-      To link with Dank Memer to get the bot perks, go to a place where you can run bot commands, and run \`pls link\`.
-      The process might take some time, So don't worry if it does. Once it is linked your pledge should appear at the bottom when you do pls profile.
-      
-      \`pls redeem\` and you'll be given your lootbox(es) - cooldown of 3 days.
-      \`pls pserver add\` in the server where you want to add perks if your pledge is high enough
-      
-**__Lootboxes__**
-      If you purchased lootboxes, they will generally arrive within 5 minutes to your inventory (\`pls inventory\`).
-      If they aren't there after 48 hours, verify on our website that you were logged into the correct account.
-      
-      **If this still doesn't answer your question about Patreon or Lootboxes**
-      Please visit the FAQ on our website: <https://dankmemer.lol/faq>
-
-      Or you can go back to the help-desk channel and select the last item on the list to talk to a moderator.`,
+      message: () => `**__Patreon Perks__**\n\nMake sure you have your Discord linked with your Patreon.\nIf you haven't, You can do that by going to the Apps section from your user settings:\n**<https://www.patreon.com/settings/apps>**\nAfter successfully doing so, you will have the donor roles.\n\nTo link with Dank Memer to get the bot perks, go to a place where you can run bot commands, and run \`pls link\`.\nThe process might take some time, So don't worry if it does. Once it is linked your pledge should appear at the bottom when you do pls profile.\n\n\`pls redeem\` and you'll be given your lootbox(es) - cooldown of 3 days.\n\`pls pserver add\` in the server where you want to add perks if your pledge is high enough.\n\n**__Lootboxes__**\n- If you purchased lootboxes, they will generally arrive within 5 minutes to your inventory (\`pls inventory\`).\n- If they aren't there after 48 hours, verify on our website that you were logged into the correct account.\n\n**If this still doesn't answer your question about Patreon or Lootboxes**\n\nPlease visit the FAQ on our website: **<https://dankmemer.lol/faq>**\nOr you can go back to the help-desk channel and select the last item on the list to talk to a moderator.`,
     },
     '2': {
       description: 'Help with setting up the bot',
-      message: () => `**We have a YouTube playlist**: <https://www.youtube.com/playlist?list=PLVYqhnJuxTsMeTtUvBph5huv46B8phNHh>
-
-**We have a FAQ page**: <https://dankmemer.lol/faq>
-
-      If you are still having issues, or neither of those options are advanced enough for what you are trying to accomplish, you can go back to the help-desk channel and select the last item on the list to talk to a moderator.`,
+      message: () => `**We have a YouTube playlist**: <https://www.youtube.com/playlist?list=PLVYqhnJuxTsMeTtUvBph5huv46B8phNHh>\n\n**We have a FAQ page**: <https://dankmemer.lol/faq>\n\nIf you are still having issues, or neither of those options are advanced enough for what you are trying to accomplish, you can go back to the help-desk channel and select the last item on the list to talk to a moderator.`,
     },
     '3': {
       description: 'Bot ban, bot blacklist, or server ban questions',
-      message: () => `**To appeal any type of ban, you may visit our website**: https://dankmemer.lol/appeals (Make sure you're logged in to be able to sumbit)
-      
-      We read all appeals within a week. If you have not heard back after that time period, it is likely denied. You are able to appeal again if you'd like.
-      
-      If this doesn't answer your question, you can go back to the help-desk channel and select the last item on the list to talk to a moderator.
-      (Moderators don't have access to your personal data on the bot, so they cannot see reasons for your ban. You either broke server rules, or bot rules listed at <https://dankmemer.lol/rules>)`
+      message: () => `**To appeal any type of ban, you may visit our website**: **https://dankmemer.lol/appeals**\n(*Make sure you're logged in to be able to submit*)\n\nWe read all appeals within a week. If you have not heard back after that time period, it is likely denied. You are able to appeal again if you'd like.\nIf this doesn't answer your question, you can go back to the help-desk channel and select the last item on the list to talk to a moderator.\n\n**__Please Note__**: Moderators *don't* have access to your personal data on the bot, so they cannot see reasons for your ban. You either broke server rules, or bot rules listed at <https://dankmemer.lol/rules>`
     },
     '4': {
       description: 'Non-Issue related Dank Memer questions.',
-      message: () => `**Our support is not for these types of questions.**
-      
-      Due to the mass influx of these types of questions, we employ an attitude of "try it and see". Our support channel is for advanced issues, bugs, etc.
-      
-      If you are unable to figure out what your question might be, it might get a response from our dedicated subreddit users: https://www.reddit.com/r/dankmemer/`,
+      message: () => `**Our support is not for these types of questions.**\n\nDue to the mass influx of these types of questions, we employ an attitude of "try it and see". Our support channel is for advanced issues, bugs, etc.\n\nIf you are unable to figure out what your question might be, it might get a response from our dedicated subreddit users: https://www.reddit.com/r/dankmemer/`,
     },
     '5': {
       description: 'Having an issue with Dank Memer, seems like a bug.',
-      message: () => `First, make sure whatever "bug" you are experiencing isn't an intended change posted in the last few posts of <#599044275291947016>. That channel contains all our update notes.\n\nIf it is not, please go back to the help-desk channel and select the last option to speak with a support staff member.`,
+      message: () => `First, make sure whatever "bug" you are experiencing isn't an intended change posted in the last few posts of <#599044275291947016>. That channel contains all of our update notes.\n\nIf it is not, please go back to the help-desk channel and select the last option to speak with a support staff member.`,
     },
     '6': {
       description: 'Dank Memer Community Server',
-      message: () => `**This server is for Dank Memer BOT SUPPORT. We do not answer questions about the community server.**
-      
-      If you are trying to appeal a ban, just select the "support server" option from the appeals page at <https://dankmemer.lol/appeals>.
-      If it is a question about the server, ask the staff team within the server.`,
+      message: () => `**This server is for Dank Memer BOT SUPPORT. We do not answer questions about the community server.**\n\n— If it is a question about the server, ask the staff team within the server.\n— If you are trying to appeal a server ban, just select the "support server" option from the appeals page at **<https://dankmemer.lol/appeals>**`,
     },
     '7': {
       description: 'Report someone for breaking rules.',
-      message: () => `**To report someone from breaking our rules (<https://dankmemer.lol/rules>)**
-      
-      Please visit https://dankmemer.lol/reports.
-      
-NOTE: You must be signed in to submit a report, and to include images you must send them as links in the report.
-      To get someone's ID, follow this video: <https://www.youtube.com/watch?v=6dqYctHmazc>`,
+      message: () => `**To report someone for breaking our rules, please visit https://dankmemer.lol/reports**\n\nTo add proof for your report:\n— Upload it to any server or imgur\n— Copy the image link, and paste it in your report\n**Note: You'll need to log into website to submit the form.**\n\nFull list of rules: <https://dankmemer.lol/rules>`,
     },
     '8': {
       description: 'How to get updates messages in your server.',
@@ -101,8 +61,8 @@ NOTE: You must be signed in to submit a report, and to include images you must s
         msg.member.addRole(config.supportRole, 'needs supportive people in their life');
         const dmChannel = await bot.getDMChannel(msg.author.id);
         try {
-          await dmChannel.createMessage(`I have given you access to <#${config.supportChannel}>`);
-        } catch (e) {
+            await dmChannel.createMessage(`I have given you access to <#${config.supportChannel}>`);
+          } catch (e) {
           return `${msg.member.author} I have given you access to <#${config.supportChannel}>`;
         }
       }

--- a/bot.js
+++ b/bot.js
@@ -58,11 +58,16 @@ const options = {
     '10': {
       description: 'General Inquiries',
       custom: async (msg) => {
+        const hasRole = msg.member.roles.includes(config.supportRole)
         msg.member.addRole(config.supportRole, 'needs supportive people in their life');
         const dmChannel = await bot.getDMChannel(msg.author.id);
         try {
+          if (hasRole) {
+            await dmChannel.createMessage(`You already have access to <#${config.supportChannel}>`)
+          } else {
             await dmChannel.createMessage(`I have given you access to <#${config.supportChannel}>`);
-          } catch (e) {
+          }
+        } catch (e) {
           return `${msg.member.author} I have given you access to <#${config.supportChannel}>`;
         }
       }


### PR DESCRIPTION
- Reformat most responses, remove indentations, while keeping boldened text and links etc. in their respective places.
- Changed the response for #7 (reports) as per [ticket #2979](https://i.imgur.com/fihTHeY.png)
- Added functionality to check if the user already has the support role, it DM's them [this](https://i.imgur.com/DyhgUmP.png) insteaed if they do.

All changed tested, everything works and appears as intended.